### PR TITLE
Fix/GetNewImagesToVote

### DIFF
--- a/TheImageComparer.Logic/Helpers/ImageModelExtensions.cs
+++ b/TheImageComparer.Logic/Helpers/ImageModelExtensions.cs
@@ -6,6 +6,16 @@ public static class ImageModelExtensions
     public static int GetVotesForCount(this ImageModel image) => image.VotesFor.Count;
     public static int GetVotesAgainstCount(this ImageModel image) => image.VotesAgainst.Count;
     public static int GetVotesCount(this ImageModel image) => image.GetVotesForCount() + image.GetVotesAgainstCount();
-    public static int GetScore(this ImageModel image) => (image.GetVotesForCount() * 1000) / image.GetVotesCount();
+    public static int GetScore(this ImageModel image)
+    {
+        int imageCount = image.GetVotesCount();
+        if (imageCount == 0)
+        {
+            return 0;
+        }
+
+        return (image.GetVotesForCount() * 1000) / image.GetVotesCount();
+    }
+
     public static List<VoteModel> GetAllVotes(this ImageModel image) => image.VotesFor.Concat(image.VotesAgainst).ToList();
 }

--- a/TheImageComparer.Logic/Services/ImageComparerService.cs
+++ b/TheImageComparer.Logic/Services/ImageComparerService.cs
@@ -68,7 +68,7 @@ public class ImageComparerService : IImageComparerService
         return availableImages;
     }
 
-    private static IEnumerable<ImageModel> ExcludeAnotherImageAndAlreadyVoted(ImageModel? anotherImage, IEnumerable<ImageModel> filteredImages)
+    private static IEnumerable<ImageModel> ExcludeAnotherImageAndAlreadyVoted(ImageModel anotherImage, IEnumerable<ImageModel> filteredImages)
     {
         List<int> idsToExclude = [anotherImage.Id];
 
@@ -99,8 +99,7 @@ public class ImageComparerService : IImageComparerService
     private static IEnumerable<ImageModel> FilterByScore(VoteMode voteMode, IEnumerable<ImageModel> filteredImages)
     {
         var groupedByScore = filteredImages
-                        .GroupBy(i => i.GetScore())
-                        .ToList();
+                        .GroupBy(i => i.GetScore());
 
         if (LowestScoreFirst(voteMode))
         {
@@ -114,14 +113,14 @@ public class ImageComparerService : IImageComparerService
         return filteredImages;
     }
 
-    private static IEnumerable<ImageModel> FilterLowestScore(List<IGrouping<int, ImageModel>> groupedByScore)
+    private static IEnumerable<ImageModel> FilterLowestScore(IEnumerable<IGrouping<int, ImageModel>> groupedByScore)
     {
         return groupedByScore
                         .OrderBy(g => g.Key)
                         .First(g => g.Any());
     }
 
-    private static IEnumerable<ImageModel> FilterHighestScore(List<IGrouping<int, ImageModel>> groupedByScore)
+    private static IEnumerable<ImageModel> FilterHighestScore(IEnumerable<IGrouping<int, ImageModel>> groupedByScore)
     {
         return groupedByScore
                         .OrderByDescending(g => g.Key)

--- a/TheImageComparer.UI/Views/VoteView.xaml
+++ b/TheImageComparer.UI/Views/VoteView.xaml
@@ -12,6 +12,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
@@ -24,8 +25,10 @@
         <Button Grid.Row="0" Grid.Column="0" Command="{Binding GoBackCommand}">Back</Button>
 
         <ComboBox Grid.Row="0" Grid.Column="1" SelectedItem="{Binding VoteMode}" ItemsSource="{Binding VoteModeValues}"/>
+        
+        <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Command="{Binding GetNewImagesCommand}">Get Images To Vote</Button>
 
-        <WrapPanel Grid.Row="1" Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <WrapPanel Grid.Row="2" Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
             <WrapPanel.Triggers>
                 <EventTrigger RoutedEvent="Image.MouseUp">
                     <BeginStoryboard>
@@ -46,7 +49,7 @@
             </WrapPanel.Triggers>
             <controls:RoundedImage ImageSource="{Binding ImageLeft.FilePath}" Margin="5"/>
         </WrapPanel>
-        <WrapPanel Grid.Row="1" Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <WrapPanel Grid.Row="2" Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
             <WrapPanel.Triggers>
                 <EventTrigger RoutedEvent="Image.MouseUp">
                     <BeginStoryboard>
@@ -68,13 +71,13 @@
             <controls:RoundedImage ImageSource="{Binding ImageRight.FilePath}" Margin="5"/>
         </WrapPanel>
 
-        <controls:ImageSummaryPanel Grid.Row="2" Grid.Column="0" Image="{Binding ImageLeft}"/>
-        <controls:ImageSummaryPanel Grid.Row="2" Grid.Column="1" Image="{Binding ImageRight}"/>
+        <controls:ImageSummaryPanel Grid.Row="3" Grid.Column="0" Image="{Binding ImageLeft}"/>
+        <controls:ImageSummaryPanel Grid.Row="3" Grid.Column="1" Image="{Binding ImageRight}"/>
 
-        <Button Grid.Row="3" Grid.Column="0" Command="{Binding VoteCommand}" CommandParameter="{Binding ImageLeft}">Vote</Button>
-        <Button Grid.Row="3" Grid.Column="1" Command="{Binding VoteCommand}" CommandParameter="{Binding ImageRight}">Vote</Button>
+        <Button Grid.Row="4" Grid.Column="0" Command="{Binding VoteCommand}" CommandParameter="{Binding ImageLeft}">Vote</Button>
+        <Button Grid.Row="4" Grid.Column="1" Command="{Binding VoteCommand}" CommandParameter="{Binding ImageRight}">Vote</Button>
 
-        <Grid x:Name="imageLeftPreviewOverlay" Grid.RowSpan="3" Grid.ColumnSpan="2" Visibility="Hidden">
+        <Grid x:Name="imageLeftPreviewOverlay" Grid.RowSpan="5" Grid.ColumnSpan="2" Visibility="Hidden">
             <Grid.Triggers>
                 <EventTrigger RoutedEvent="Grid.MouseUp">
                     <BeginStoryboard>
@@ -99,7 +102,7 @@
             </WrapPanel>
         </Grid>
         
-        <Grid x:Name="imageRightPreviewOverlay" Grid.RowSpan="3" Grid.ColumnSpan="2" Visibility="Hidden">
+        <Grid x:Name="imageRightPreviewOverlay" Grid.RowSpan="5" Grid.ColumnSpan="2" Visibility="Hidden">
             <Grid.Triggers>
                 <EventTrigger RoutedEvent="Grid.MouseUp">
                     <BeginStoryboard>


### PR DESCRIPTION
Fixed issue that occured when new images were added, because score was calculated with no guards against division by 0.

The issue was somewhat hidden, because the debugger would not show me the exception being thrown and just exit out of some other method without hitting my breakpoints. I'm still a little confused as of why it behaved like this, but I somehow managed to trigger the exception once and find it.

This goes to show that I need to add unit tests as soon as possible.